### PR TITLE
fix http server error

### DIFF
--- a/shingetsu/LightCGIHTTPServer.py
+++ b/shingetsu/LightCGIHTTPServer.py
@@ -84,14 +84,16 @@ class HTTPRequestHandler(http.server.CGIHTTPRequestHandler):
     root_index = "/"
 
     def parse_request(self):
-        r = super().parse_request()
+        ok = super().parse_request()
+        if not ok:
+            return False
         found = re.search(r'^/+([?].*)?$', self.path)
         if found:
             if found.group(1):
                 self.path = self.root_index + found.group(1)
             else:
                 self.path = self.root_index
-        return r
+        return True
 
     def is_cgi(self):
         """Test request URI is *.cgi."""


### PR DESCRIPTION
不正なHTTPリクエストを受け取ったときに`LightCGIHTTPServer.py:88`でAttributeErrorが発生する問題を修正しました。
原因は、`super().parse_request()`から制御が戻ったときにself.pathが未定義になっているからです。