### PR TITLE
GzipFile mode

### DIFF
--- a/shingetsu/server_cgi.py
+++ b/shingetsu/server_cgi.py
@@ -188,7 +188,7 @@ class CGI(basecgi.CGI):
         encoding = self.environ.get("HTTP_ACCEPT_ENCODING", "")
         if (encoding.find("gzip") >= 0) or (encoding.find("*") >= 0):
             self.header("text/plain", {"Content-Encoding": "gzip"})
-            fp = gzip.GzipFile(fileobj=self.stdout)
+            fp = gzip.GzipFile(fileobj=self.stdout,mode="wb")
         else:
             self.header("text/plain")
             fp = self.stdout

--- a/shingetsu/server_cgi.py
+++ b/shingetsu/server_cgi.py
@@ -1,7 +1,7 @@
 """Server CGI methods.
 """
 #
-# Copyright (c) 2005-2019 shinGETsu Project.
+# Copyright (c) 2005-2022 shinGETsu Project.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
以下の警告に対処しました。

FutureWarning: GzipFile was opened for writing, but this will change in future Python releases.  Specify the mode argument for opening it for writing.
  fp = gzip.GzipFile(fileobj=self.stdout)