### PR TITLE
StopIteration fault

### DIFF
--- a/shingetsu/node.py
+++ b/shingetsu/node.py
@@ -118,7 +118,6 @@ class SocketIO:
                 yield str(line, 'utf-8', 'replace')
         except Exception as err:
             sys.stderr.write('%s: %s\n' % (self.msg, err))
-            raise StopIteration
 
 # End of SocketIO
 


### PR DESCRIPTION
joinに対してWELCOMEが帰ってこないとエラーメッセージが表示されるのはずっと仕様だと思っていたのですが、ジェネレータが値を生成することなく終了すると自動でStopIterationが発生するので明示的にraiseすると意図せぬ動作をするようです。
と言うわけで修正です。