### PR TITLE
make git2ver.sh compatible with *BSD and macOS

### DIFF
--- a/tool/git2ver.sh
+++ b/tool/git2ver.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 # git log format to version string
 #
-git log -n 1 --pretty=format:"%ai" |
-    env TZ=UTC xargs -0 date +'%Y%m%d-%H%M' --date
+case $(uname) in
+Linux)
+    git log -n 1 --pretty=format:"%ai" |
+        env TZ=UTC xargs -0 date +'%Y%m%d-%H%M' --date
+    ;;
+Darwin|DragonFly|FreeBSD|NetBSD|OpenBSD)
+    git log -n 1 --pretty=format:"%ai" |
+        env TZ=UTC xargs -0 date -jf '%Y-%m-%d %H:%M:%S %z' +'%Y%m%d-%H%M'
+    ;;
+esac


### PR DESCRIPTION
### 現象

FreeBSD上でgit2ver.shを利用できません。（環境：FreeBSD 13.1）
```console
% ./git2ver.sh 
date: illegal time format
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[[[cc]yy]mm]dd]HH]MM[.SS] | new_date] [+output_fmt]
```

### 修正

BSD系OSやmacOSのdateコマンドはGNU/Linuxとオプションが違うため、OSを判別し環境に合わせてオプション指定するようにしました。