### PR TITLE
Pytest: Fix `tests/test_attachutil.py` warnings and indent

### DIFF
--- a/tests/test_attachutil.py
+++ b/tests/test_attachutil.py
@@ -1,7 +1,7 @@
 """Unittest for Attached Files Utilities.
 """
 #
-# Copyright (c) 2009 shinGETsu Project.
+# Copyright (c) 2023 shinGETsu Project.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,11 +30,11 @@ import imghdr
 import sys
 import unittest
 
-sys.path.append('.')
+sys.path.append(".")
 
 import shingetsu.attachutil as attachutil
 
-__version__ = '$Revision$'
+__version__ = "$Revision$"
 
 
 class ImghdrMock:
@@ -52,29 +52,29 @@ class AttachUtilTest(unittest.TestCase):
         attachutil._imghdr = imghdr
 
     def test_is_valid_image_true(self):
-        attachutil._imghdr = ImghdrMock('png')
-        self.assertTrue(attachutil.is_valid_image('image/png', 'foo'))
-        self.assertEquals('foo', attachutil._imghdr.path)
+        attachutil._imghdr = ImghdrMock("png")
+        self.assertTrue(attachutil.is_valid_image("image/png", "foo"))
+        self.assertEqual("foo", attachutil._imghdr.path)
 
     def test_is_valid_image_type_isnot_image(self):
-        attachutil._imghdr = ImghdrMock('png')
-        self.assertFalse(attachutil.is_valid_image('text/html', 'foo'))
-        self.assertEquals('foo', attachutil._imghdr.path)
- 
+        attachutil._imghdr = ImghdrMock("png")
+        self.assertFalse(attachutil.is_valid_image("text/html", "foo"))
+        self.assertEqual("foo", attachutil._imghdr.path)
+
     def test_is_valid_image_file_isnot_image(self):
         attachutil._imghdr = ImghdrMock(None)
-        self.assertFalse(attachutil.is_valid_image('image/png', 'foo'))
-        self.assertEquals('foo', attachutil._imghdr.path)
+        self.assertFalse(attachutil.is_valid_image("image/png", "foo"))
+        self.assertEqual("foo", attachutil._imghdr.path)
 
     def test_is_valid_image_not_same_image_type(self):
-        attachutil._imghdr = ImghdrMock('jpeg')
-        self.assertFalse(attachutil.is_valid_image('image/png', 'foo'))
-        self.assertEquals('foo', attachutil._imghdr.path)
+        attachutil._imghdr = ImghdrMock("jpeg")
+        self.assertFalse(attachutil.is_valid_image("image/png", "foo"))
+        self.assertEqual("foo", attachutil._imghdr.path)
 
     def test_is_valid_image_none(self):
-        attachutil._imghdr = ImghdrMock('jpeg')
-        self.assertFalse(attachutil.is_valid_image('image/png', None))
-        self.assertEquals(None, attachutil._imghdr.path)
+        attachutil._imghdr = ImghdrMock("jpeg")
+        self.assertFalse(attachutil.is_valid_image("image/png", None))
+        self.assertEqual(None, attachutil._imghdr.path)
 
 
 def _test():
@@ -85,5 +85,5 @@ def _test():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _test()


### PR DESCRIPTION
GitHub Actions の `Test with Pytest` で出力される `DeprecationWarning: Please use assertEqual instead.` という警告について修正を行いました。

https://github.com/shingetsu/saku/actions/runs/5708507728/job/15466246336

### 対応前のログ

```
$ pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.4, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/takano32/GitHub/saku
collected 5 items

tests/test_attachutil.py .....                                                                                               [100%]

========================================================= warnings summary =========================================================
tests/test_attachutil.py:29
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:29: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
    import imghdr

tests/test_attachutil.py::AttachUtilTest::test_is_valid_image_file_isnot_image
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:67: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("foo", attachutil._imghdr.path)

tests/test_attachutil.py::AttachUtilTest::test_is_valid_image_none
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:77: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(None, attachutil._imghdr.path)

tests/test_attachutil.py::AttachUtilTest::test_is_valid_image_not_same_image_type
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:72: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("foo", attachutil._imghdr.path)

tests/test_attachutil.py::AttachUtilTest::test_is_valid_image_true
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:57: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("foo", attachutil._imghdr.path)

tests/test_attachutil.py::AttachUtilTest::test_is_valid_image_type_isnot_image
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:62: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("foo", attachutil._imghdr.path)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 5 passed, 6 warnings in 0.06s ===================================================
```

### 対応後のログ

```
$ pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.4, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/takano32/GitHub/saku
collected 5 items

tests/test_attachutil.py .....                                                                                               [100%]

========================================================= warnings summary =========================================================
tests/test_attachutil.py:29
  /Users/takano32/GitHub/saku/tests/test_attachutil.py:29: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
    import imghdr

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 5 passed, 1 warning in 0.06s ===================================================
```

## 所感

`assertEquals` を `assertEqual` に書き換えて警告を減らしました。

他には `DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13` という警告が残っていて対応しようと考えていますが、この警告だけ複雑な修正になりそうなので別の PR で出します。

参考: https://github.com/sphinx-doc/sphinx/issues/10440

ファイルを修正するときにエディタのフックで [black](https://github.com/psf/black) による整形も走って変更箇所が出てきました。セマンティックは同じなのでこの PR にふくめています。この修正は構成管理・版管理のポリシーによっては別の PR で出した方がよいかもしれないとも考えましたが、今回は単一のファイルの修正で、この PR でも理解でき問題なさそうだと判断しましたが、もし問題がある場合はお伝えいただければこれも別の PR にして分けます。

行数ベースでの集計ですと差分が多くて恐縮ですが、`black` による整形の変更は主に文字列リテラルに `'` ではなくて `"` を使うべきというのスタイルガイドに習った変更になります。

https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#strings

----

Fix `tests/test_attachutil.py`

* Fix warnings displaying `DeprecationWarning: Please use assertEqual instead.`
* Formatting  with `black` for PEP8 compliant and so on.