### PR TITLE
Update year description at `Copyright (c)`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 COPY . /saku
 WORKDIR /saku
 RUN mv file/saku.ini.docker file/saku.ini
-RUN python -m pip install -U pip
+RUN python -m pip install --upgrade pip
 RUN python -m pip install pipenv
 RUN pipenv install
 

--- a/file/saku.ini.docker
+++ b/file/saku.ini.docker
@@ -1,6 +1,6 @@
 #
 # Sample saku.ini to run saku in distributed directory.
-# Copyright (c) 2005-2011 shinGETsu Project.
+# Copyright (c) 2005-2023 shinGETsu Project.
 # $Id$
 #
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -2,7 +2,7 @@
 #
 # Run All Automatic Tests.
 #
-# Copyright (c) 2009-2014 shinGETsu Project.
+# Copyright (c) 2009-2023 shinGETsu Project.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
PR 26 から PR 31 あたりで修正したファイルのうち `saku.ini.docker` と `runtests.sh` の編集でファイル先頭の コピーライトの年を更新し忘れていたのでその修正です。

ほか、少し違和感のあった `pip` の引数の表記を変えました。