### PR TITLE
Use full path to `date(1)` command in `git2ver.sh`

### DIFF
--- a/tool/git2ver.sh
+++ b/tool/git2ver.sh
@@ -4,10 +4,10 @@
 case $(uname) in
 Linux)
     git log -n 1 --pretty=format:"%ai" |
-        env TZ=UTC xargs -0 date +'%Y%m%d-%H%M' --date
+        env TZ=UTC xargs -0 /bin/date +'%Y%m%d-%H%M' --date
     ;;
 Darwin|DragonFly|FreeBSD|NetBSD|OpenBSD)
     git log -n 1 --pretty=format:"%ai" |
-        env TZ=UTC xargs -0 date -jf '%Y-%m-%d %H:%M:%S %z' +'%Y%m%d-%H%M'
+        env TZ=UTC xargs -0 /bin/date -jf '%Y-%m-%d %H:%M:%S %z' +'%Y%m%d-%H%M'
     ;;
 esac


### PR DESCRIPTION
`git2ver.sh` の `date(1)` を使うところでフルパスで実行するようにしました。

モチベーションとしては macOS や FreeBSD などで GNU の `date(1)` を homebrew や `pkg(8)` で `/usr/local/bin/date` などに入れてパスを通した環境では Linux と同じ `date(1)` の挙動なのに BSD のほうに分岐してしまって動かないので、それを動くようにしたい修正になります。

`gdate` が `which` で見つかって `date` が `/bin/date` ではない(`/usr/local/bin/date` など) ときは Linux として扱う…みたいな条件で分岐するという方針も考えましたが、ちょっと字面から想像しただけでも複雑なわりにメリットがないのでフルパス指定にするのがよいのではないかと考えました。