### PR TITLE
Remove `ruff` from `Pipfile`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 jinja2 = "*"
 pillow = "*"
-ruff = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
`ruff` is only used with GitHub Actions

間違えて #37 に入れてしまいました。すみません。 🙇 