### PR TITLE
support specify bind address

### DIFF
--- a/doc/sample.ini
+++ b/doc/sample.ini
@@ -4,6 +4,9 @@
 #
 
 [Network]
+# Bind Address(Default: *)
+bind_addr: 
+
 #  Listening TCP port.
 port: 8000
 
@@ -90,6 +93,8 @@ archive_uri: https://archive.shingetsu.info/
 # 2ch-interface
 enable_2ch: no
 
+# use X-FORWARDED-FOR if defined.
+use_x_forwarded_for: no
 
 [Application Thread]
 # Time range for saving records. (seconds)

--- a/doc/sample.ini
+++ b/doc/sample.ini
@@ -19,6 +19,9 @@ max_connection: 20
 # Server name for shinGETsu protocol
 dnsname:
 
+# use X-FORWARDED-FOR if defined.
+use_x_forwarded_for: no
+
 [Path]
 prefix: /usr/local
 var: /var/local
@@ -92,9 +95,6 @@ archive_uri: https://archive.shingetsu.info/
 
 # 2ch-interface
 enable_2ch: no
-
-# use X-FORWARDED-FOR if defined.
-use_x_forwarded_for: no
 
 [Application Thread]
 # Time range for saving records. (seconds)

--- a/shingetsu/config.py
+++ b/shingetsu/config.py
@@ -69,6 +69,7 @@ _extconf.read(['file/saku.ini',
 # Application types
 types = ("thread",)
 
+bind_addr = _get_value(_extconf, 'Network', 'bind_addr', '')
 port = _get_value(_extconf, 'Network', 'port', 8000, 'int')
 dat_port = _get_value(_extconf, 'Network', 'dat_port', 8001, 'int')
 max_connection = _get_value(_extconf, 'Network', 'max_connection', 20, 'int')
@@ -109,6 +110,7 @@ proxy_destination = _get_value(_extconf, 'Gateway', 'proxy_destination', '')
 archive_uri = _get_value(_extconf, 'Gateway', 'archive_uri',
                          'https://archive.shingetsu.info/')
 enable2ch = _get_value(_extconf, 'Gateway', 'enable_2ch', False, 'boolean')
+use_x_forwarded_for = _get_value(_extconf, 'Gateway', 'use_x_forwarded_for', False, 'boolean') # set true if behind a reverse proxy.
 re_admin = re.compile(admin)
 re_friend = re.compile(friend)
 re_visitor = re.compile(visitor)

--- a/shingetsu/config.py
+++ b/shingetsu/config.py
@@ -73,6 +73,7 @@ bind_addr = _get_value(_extconf, 'Network', 'bind_addr', '')
 port = _get_value(_extconf, 'Network', 'port', 8000, 'int')
 dat_port = _get_value(_extconf, 'Network', 'dat_port', 8001, 'int')
 max_connection = _get_value(_extconf, 'Network', 'max_connection', 20, 'int')
+use_x_forwarded_for = _get_value(_extconf, 'Network', 'use_x_forwarded_for', False, 'boolean') # set true if behind a reverse proxy.
 
 docroot = _get_value(_extconf, 'Path', 'docroot', './www', 'path')
 log_dir = _get_value(_extconf, 'Path', 'log_dir', './log', 'path')
@@ -110,7 +111,6 @@ proxy_destination = _get_value(_extconf, 'Gateway', 'proxy_destination', '')
 archive_uri = _get_value(_extconf, 'Gateway', 'archive_uri',
                          'https://archive.shingetsu.info/')
 enable2ch = _get_value(_extconf, 'Gateway', 'enable_2ch', False, 'boolean')
-use_x_forwarded_for = _get_value(_extconf, 'Gateway', 'use_x_forwarded_for', False, 'boolean') # set true if behind a reverse proxy.
 re_admin = re.compile(admin)
 re_friend = re.compile(friend)
 re_visitor = re.compile(visitor)

--- a/shingetsu/gateway.py
+++ b/shingetsu/gateway.py
@@ -45,7 +45,7 @@ from .title import *
 from .tag import *
 from .template import Template
 from .updatequeue import UpdateQueue
-from .util import opentext
+from .util import opentext, get_http_remote_addr
 
 
 dummyquery = str(int(time.time()));
@@ -138,7 +138,7 @@ class CGI(basecgi.CGI):
         else:
             al = ""
         self.message = search_message(al)
-        addr = self.environ.get("REMOTE_ADDR", "")
+        addr = get_http_remote_addr(self.environ)
         self.remoteaddr = addr
         self.isadmin = config.re_admin.search(addr)
         self.isfriend = config.re_friend.search(addr)

--- a/shingetsu/httpd.py
+++ b/shingetsu/httpd.py
@@ -48,7 +48,7 @@ class Httpd(threading.Thread):
         HandlerClass = LightCGIHTTPServer.HTTPRequestHandler
 
         ServerClass = LightCGIHTTPServer.HTTPServer
-        server_address = ("", config.port)
+        server_address = (config.bind_addr, config.port)
         HandlerClass.server_version = config.version
         HandlerClass.root_index = config.root_index
         self.httpserv = ServerClass(server_address, HandlerClass)

--- a/shingetsu/util.py
+++ b/shingetsu/util.py
@@ -29,6 +29,7 @@
 import hashlib
 import os.path
 import sys
+from . import config
 
 __all__ = ['md5digest', 'fsdiff', 'opentext']
 
@@ -73,3 +74,13 @@ def opentext(path, mode='r'):
     return open(path, mode,
                 encoding='utf-8', errors='replace',
                 newline=newline)
+
+def get_http_remote_addr(env):
+    if not config.use_x_forwarded_for:
+        return env['REMOTE_ADDR']
+    else:
+        if 'HTTP_X_FORWARDED_FOR' in env:
+            return env['HTTP_X_FORWARDED_FOR']
+        elif 'REMOTE_ADDR' in env:
+            return env['REMOTE_ADDR']
+    return None


### PR DESCRIPTION
### バインドアドレスの指定

リバースプロキシを置いた構成を実現する為にバインドするアドレスを指定できるようにしました。
saku.iniのNetworkセクションで指定します。
空欄、若しくは設定自体が書かれていない場合は、今まで通り`0.0.0.0`でバインドされます。
saku.ini
```
[Network]
bind_addr: 127.0.0.1
```

### リモートホストアドレスの取得方法の変更

リバースプロキシ構成の場合、接続元ホストのIPアドレスは`REMOTE_ADDR`ではなく`X-FORWARDED-FOR`で取得するのが一般的なので`saku.ini`で、`X-FORWARDED-FOR`を優先的に参照するかどうかのフラグをGatewayセクションに追加しました。
`no` 若しくは設定が書かれていない場合は、今までと同様に`REMOTE_ADDR`から接続元ホストのIPアドレスを取得します。
saku.ini
```
[Gateway]
use_x_forwarded_for: yes
```

### バージョンを返すAPI

テストでいくつかプロセスを上げている時に参照できると便利かもと思ったのですが、不要でしたらこのコードを抜いてプルリクエストを出し直します。
```
% curl http://saku.loneb.net:8000/server.cgi/version
shinGETsu/0.7 (Saku/4.11.0; git/20231212-1531)
```

### 動作サンプル
* use_x_forwarded_for: no の場合
```
% curl http://saku.loneb.net:8000/server.cgi/ping
PONG
127.0.0.1
```

*  use_x_forwarded_for: yes の場合
```
% curl http://saku.loneb.net:8000/server.cgi/ping
PONG
124.87.yyy.xxx
```
